### PR TITLE
Updated C# usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,9 @@
 **Server Side:** Use code like...
 
 ```cs
-Request.Browser["IsMobile"]
-```
-
-or 
-
-```cs
-Request.Browser["IsTablet"]
+//Request is of class HttpRequest
+if (Request.Browser.IsMobileDevice)
+{ }
 ```
 
 ... from within a web application server side to determine the requesting device type.


### PR DESCRIPTION
The syntax Request.Browser["IsMobile"] does not compile when I tested it. Also, the class of Request needs to be clarified, as C# has both HttpRequest and HttpWebRequest.